### PR TITLE
fix ownership of postgresql.conf backup file

### DIFF
--- a/tasks/slave.yml
+++ b/tasks/slave.yml
@@ -19,7 +19,7 @@
     group: postgres
     mode: 0644
 
-- name: Ensable hot standby
+- name: Enable hot standby
   lineinfile:
     state: present
     backup: yes
@@ -27,6 +27,8 @@
     regexp: '^#?hot_standby = \w+(\s+#.*)'
     line: 'hot_standby = yes\1'
     backrefs: yes
+  become: yes
+  become_user: postgres
 
 - name: Start and enable PostgreSQL
   service:


### PR DESCRIPTION
With the previous version, the postgresql.conf backup file is owned by root. This breaks pg_basebackup on the standby server, because the postgres user cannot read the backup file (pg_basebackup tries to copy all files from the data directory).

Running pg_basebackup on the standby server is useful when you failed over to it and want to switch back to the primary.
