### PR TITLE
add documentation for bundle installer usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Role Variables
 | Name              | Default Value       | Description          |
 |-------------------|---------------------|----------------------|
 | `pg_port` | `5432` | PostgreSQL port |
+| `bundle_install` | `False` | Set to `True` if using the Bundle Installer |
 | `postgresrep_role` | `skip` | `master` or `slave`, which determinse which tasks run on the host |
 | `postgresrep_user` | `replicator` | User account that will be created and used for replication. |
 | `postgresrep_password` | `[undefined]` | Password for replication account |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,7 @@
 pg_port: 5432
 
+bundle_install: False
+
 postgresrep_role: skip
 postgresrep_user: replicator
 #postgresrep_password: '' # Store this in an Ansible vault


### PR DESCRIPTION
Just wanted to add this- if people are using the setup.sh script, they may not realize they are passing `-e bundle_install=True`