### PR TITLE
Modified for Postgresql 9.6. Updated documentation.

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,4 @@
 - name: restart postgresql
   service:
-    name: postgresql-9.4
+    name: postgresql-9.6
     state: restarted

--- a/tasks/master.yml
+++ b/tasks/master.yml
@@ -2,7 +2,7 @@
   lineinfile:
     state: present
     backrefs: yes
-    dest: /var/lib/pgsql/9.4/data/postgresql.conf
+    dest: /var/lib/pgsql/9.6/data/postgresql.conf
     regexp: "{{ item.regexp }}"
     line: "{{ item.line }}"
   with_items: "{{ postgresrep_postgres_conf_lines }}"
@@ -19,7 +19,7 @@
 - name: Add trust in pg_hba.conf
   lineinfile:
     state: present
-    dest: /var/lib/pgsql/9.4/data/pg_hba.conf
+    dest: /var/lib/pgsql/9.6/data/pg_hba.conf
     regexp: "{{ item.regexp }}"
     line: "{{ item.line }}"
   with_items: "{{ postgresrep_pg_hba_conf_lines }}"

--- a/tasks/slave.yml
+++ b/tasks/slave.yml
@@ -1,20 +1,20 @@
 - name: Stop PostgreSQL
   service:
-    name: postgresql-9.4
+    name: postgresql-9.6
     state: stopped
 
 - name: Clear out data directory
-  shell: rm -rf /var/lib/pgsql/9.4/data/*
+  shell: rm -rf /var/lib/pgsql/9.6/data/*
 
 - name: Create base backup
-  command: pg_basebackup -X stream -D /var/lib/pgsql/9.4/data -h {{ postgresrep_master_address }} -U replicator
+  command: pg_basebackup -X stream -D /var/lib/pgsql/9.6/data -h {{ postgresrep_master_address }} -U replicator
   become: yes
   become_user: postgres
 
 - name: Create recovery.conf
   template:
     src: recovery.conf.j2
-    dest: /var/lib/pgsql/9.4/data/recovery.conf
+    dest: /var/lib/pgsql/9.6/data/recovery.conf
     owner: postgres
     group: postgres
     mode: 0644
@@ -23,7 +23,7 @@
   lineinfile:
     state: present
     backup: yes
-    dest: /var/lib/pgsql/9.4/data/postgresql.conf
+    dest: /var/lib/pgsql/9.6/data/postgresql.conf
     regexp: '^#?hot_standby = \w+(\s+#.*)'
     line: 'hot_standby = yes\1'
     backrefs: yes
@@ -32,6 +32,6 @@
 
 - name: Start and enable PostgreSQL
   service:
-    name: postgresql-9.4
+    name: postgresql-9.6
     state: started
     enabled: yes

--- a/tests/ansible-tower/files/psql-replication.yml
+++ b/tests/ansible-tower/files/psql-replication.yml
@@ -4,7 +4,7 @@
   pre_tasks:
     - name: Remove recovery.conf
       file:
-        path: /var/lib/pgsql/9.4/data/recovery.conf
+        path: /var/lib/pgsql/9.6/data/recovery.conf
         state: absent
 
     - name: Add slave to database group


### PR DESCRIPTION
I made the minimum modifications for the role to work in Portgresql 9.6 (bundled in Tower 3.2.1). Also, made some minor updates on the documentation, including some roles I found necessary when running the example playbook on a bundled install.

Hope you find this useful!