### PR TITLE
Proposal for a better version detection

### DIFF
--- a/filter_plugins/filters.py
+++ b/filter_plugins/filters.py
@@ -8,6 +8,8 @@ from ansible.module_utils._text import to_native
 
 from distutils.version import LooseVersion
 
+import re
+
 
 def parse_psql_version(version_string):
     """Take the raw output of psql --version and return major.minor version string

--- a/filter_plugins/filters.py
+++ b/filter_plugins/filters.py
@@ -15,11 +15,10 @@ def parse_psql_version(version_string):
     Example output from psql --version
     psql (PostgreSQL) 9.6.12
     psql (PostgreSQL) 10.7
+    psql (PostgreSQL) 10.6 (Ubuntu 10.6-0ubuntu0.18.04.1)
     """
     to_native(version_string)
-    version = version_string.split(' ')[-1]
-    return '.'.join(version.split('.')[:2])
-
+    return re.search('[0-9]{1,}\.[0-9]{1,}',version_string).group()
 
 def get_psql_service_name(version):
     version = to_native(version)

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,4 @@
 - name: restart postgresql
   service:
-    name: postgresql-{{ pgsql_version }}
+    name: postgresql
     state: restarted

--- a/tasks/master.yml
+++ b/tasks/master.yml
@@ -2,7 +2,7 @@
   lineinfile:
     state: present
     backrefs: yes
-    dest: "{{ pgsqlrep_data_path }}/postgresql.conf"
+    dest: "{{ pgsqlrep_config_path }}/postgresql.conf"
     regexp: "{{ item.regexp }}"
     line: "{{ item.line }}"
   loop: "{{ pgsqlrep_postgres_conf_lines }}"

--- a/tasks/master.yml
+++ b/tasks/master.yml
@@ -19,7 +19,7 @@
 - name: Add trust in pg_hba.conf
   lineinfile:
     state: present
-    dest: "{{ pgsqlrep_data_path }}/pg_hba.conf"
+    dest: "{{ pgsqlrep_config_path }}/pg_hba.conf"
     regexp: 'host.*replication.*{{ item }}/32.*trust'
     line: 'host    replication    {{ pgsqlrep_user }}  {{ item }}/32 trust'
   loop: "{{ pgsqlrep_replica_address }}"

--- a/tasks/replica.yml
+++ b/tasks/replica.yml
@@ -14,7 +14,7 @@
 - name: Create recovery.conf
   template:
     src: recovery.conf.j2
-    dest: "{{ pgsqlrep_data_path }}/recovery.conf"
+    dest: "{{ pgsqlrep_config_path }}/recovery.conf"
     owner: postgres
     group: postgres
     mode: '0644'
@@ -23,7 +23,7 @@
   lineinfile:
     state: present
     backup: yes
-    dest: "{{ pgsqlrep_data_path }}/postgresql.conf"
+    dest: "{{ pgsqlrep_config_path }}/postgresql.conf"
     regexp: '^#?hot_standby = \w+(\s+#.*)'
     line: 'hot_standby = yes\1'
     backrefs: yes

--- a/tasks/replica.yml
+++ b/tasks/replica.yml
@@ -1,6 +1,6 @@
 - name: Stop PostgreSQL
   service:
-    name: "{{ pgsql_version | pgsql_service_string }}"
+    name: postgresql
     state: stopped
 
 - name: Clear out data directory

--- a/tasks/replica.yml
+++ b/tasks/replica.yml
@@ -32,6 +32,6 @@
 
 - name: Start and enable PostgreSQL
   service:
-    name: "{{ pgsql_version | pgsql_service_string }}"
+    name: postgresql
     state: started
     enabled: yes

--- a/tasks/replica.yml
+++ b/tasks/replica.yml
@@ -14,7 +14,7 @@
 - name: Create recovery.conf
   template:
     src: recovery.conf.j2
-    dest: "{{ pgsqlrep_config_path }}/recovery.conf"
+    dest: "{{ pgsqlrep_data_path }}/recovery.conf"
     owner: postgres
     group: postgres
     mode: '0644'


### PR DESCRIPTION
Version string is sometimes more complicated/verbose, here is a proposal to improve its detection. Based on the first XX.YY string found in psql -v output.

The data folder is so different depending on Linux/PgSQL versions, I wonder if version detection should be avoided.

By the way, service can be named "pgsql", so 'pgsql_version' variable could be removed completely.