### PR TITLE
Allow for the configuration of replication slots resolves 

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ Role Variables
 | `pgsqlrep_master_address` | `[default IPv4 of the master]` | If you need something other than the default IPv4 address, for exaample, FQDN, define it here. |
 | `pgsqlrep_replica_address` | `[default IPv4 of the replica(s)]` | If you need something other than the default IPv4 address, for exaample, FQDN, define it here. |
 | `pgsqlrep_postgres_conf_lines` | `[see defaults/main.yml]` | Lines in `postgres.conf` that are set in order to enable streaming replication. |
+| `pgsqlrep_max_replication_slots` | `10` | Max number of replication slots allowd on the master database |
+| `pgsqlrep_use_slots` | `no` | Use replication slots when setting up replication. See [documentation](https://www.postgresql.org/docs/9.6/warm-standby.html#STREAMING-REPLICATION-SLOTS) |
+| `pgsqlrep_primary_slot_name` | `[undefined]` | Set on a host to change the name of the replication slot used by a replica otherwise a system generated name is used. |
 
 
 Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,8 @@ pgsqlrep_max_wal_senders: "{{ groups[pgsqlrep_group_name] | length * 2 }}"
 pgsqlrep_wal_keep_segments: 100
 pgsqlrep_synchronous_commit: local
 pgsqlrep_application_name: awx
+pgsqlrep_max_replication_slots: 10
+pgsqlrep_use_slots: no
 bundle_install: no
 
 pgsqlrep_group_name: database_replica
@@ -31,3 +33,6 @@ pgsqlrep_postgres_conf_lines:
 
   - regexp: '#?synchronous_commit = \w+(\s+#.*)'
     line: 'synchronous_commit = {{ pgsqlrep_synchronous_commit }}\1'
+
+  - regexp: '#?max_replication_slots = \d+(\s+#.*)'
+    line: 'max_replication_slots = {{ pgsqlrep_max_replication_slots }}\1'

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Configure PostgreSQL replication between two or more nodes
   company: Red Hat
   license: Apache 2.0
-  min_ansible_version: 2.7
+  min_ansible_version: 2.8
 
   platforms:
     - name: EL

--- a/molecule/with_slots/converge.yml
+++ b/molecule/with_slots/converge.yml
@@ -1,0 +1,46 @@
+- name: Install PostgreSQL on all nodes
+  hosts: database:database_replica
+  become: yes
+  tasks:
+    - debug:
+        msg: >-
+          Testing with Ansible {{ ansible_version.full }} using Python {{ ansible_facts.python_version }}
+          on {{ ansible_facts.distribution }} {{ ansible_facts.distribution_version }}
+
+    - import_role:
+        name: repos_el
+
+    - import_role:
+        name: packages_el
+
+    - import_role:
+        name: postgres
+
+
+- name: Configure PSQL master server
+  hosts: database[0]
+  tasks:
+    - import_role:
+        name: pgsql_replication
+
+
+- name: Configure PSQL replica
+  hosts: database_replica
+  tasks:
+    - name: Find recovery.conf
+      find:
+        paths:
+          - /var/lib/pgsql
+          - /opt/rh/rh-postgresql10
+        recurse: yes
+        patterns: recovery.conf
+      register: recovery_conf_path
+
+    - name: Remove recovery.conf
+      file:
+        path: "{{ item.path }}"
+        state: absent
+      loop: "{{ recovery_conf_path.files }}"
+
+    - import_role:
+        name: pgsql_replication

--- a/molecule/with_slots/molecule.yml
+++ b/molecule/with_slots/molecule.yml
@@ -1,0 +1,86 @@
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint: |
+  ansible-lint -x 204,403,502,301,302 --exclude molecule/default/roles
+  yamllint -c molecule/default/yamllint.yml .
+platforms:
+  - name: pgsql-replication-test-master
+    groups:
+      - tower
+      - database
+    image: "quay.io/samdoran/${MOLECULE_DISTRIBUTION:-centos7}-ansible:latest"
+    command: ${MOLECULE_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: yes
+    pre_build_image: yes
+
+  - name: pgsql-replication-test-replica1
+    groups:
+      - database
+      - database_replica
+    image: "quay.io/samdoran/${MOLECULE_DISTRIBUTION:-centos7}-ansible:latest"
+    command: ${MOLECULE_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: yes
+    pre_build_image: yes
+
+  - name: pgsql-replication-test-replica2
+    groups:
+      - database
+      - database_replica
+    image: "quay.io/samdoran/${MOLECULE_DISTRIBUTION:-centos7}-ansible:latest"
+    command: ${MOLECULE_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: yes
+    pre_build_image: yes
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      stdout_callback: debug
+  playbooks:
+    converge: ${MOLECULE_PLAYBOOK:-converge.yml}
+  inventory:
+    group_vars:
+      all:
+        tower_package_name: 'ansible-tower'
+        tower_package_version: '3.6.3'
+        pgsqlrep_password: 'SammyDrakeSaturn'
+        postgres_password: 'GnomeTutuPig'
+        packages_el_install_tower: no
+        packages_el_install_postgres: yes
+        existing_pg_dir: '/var/lib/pgsql/9.6/data'
+        config_dynamic_database: internal
+        max_postgres_connections: 1024
+        postgres_shared_memory_size: "{{ (ansible_memtotal_mb*0.3)|int }}"
+        postgres_work_mem: "{{ (ansible_memtotal_mb*0.03)|int }}"
+        postgres_maintenance_work_mem: "{{ (ansible_memtotal_mb*0.04)|int }}"
+        pgsqlrep_use_slots: yes
+      database:
+        pgsqlrep_role: master
+      database_replica:
+        pgsqlrep_role: replica
+    host_vars:
+      pgsql-replication-test-replica1:
+        pgsqlrep_primary_slot_name: test1
+scenario:
+  name: with_slots
+  test_sequence:
+    - dependency
+    - lint
+    - cleanup
+    - destroy
+    - prepare
+    - syntax
+    - create
+    - converge
+    - verify
+    - cleanup
+    - destroy
+verifier:
+  name: ansible

--- a/molecule/with_slots/prepare.yml
+++ b/molecule/with_slots/prepare.yml
@@ -1,0 +1,19 @@
+- name: Download Tower roles
+  hosts: localhost
+  connection: local
+  become: no
+
+  tasks:
+    - name: Download Tower installer
+      get_url:
+        url: https://releases.ansible.com/ansible-tower/setup/ansible-tower-setup-latest.tar.gz
+        dest: "{{ playbook_dir }}"
+
+    - name: Extract roles from Tower installer
+      unarchive:
+        src: ansible-tower-setup-latest.tar.gz
+        dest: "{{ playbook_dir }}"
+        extra_opts:
+          - '--wildcards'
+          - '--strip-components=1'
+          - '*/roles'

--- a/molecule/with_slots/verify.yml
+++ b/molecule/with_slots/verify.yml
@@ -1,0 +1,40 @@
+- name: Ensure streaming replication is working on master
+  hosts: database[0]
+  tasks:
+    - name: List PostgreSQL connections
+      command: ss --no-header --tcp --ipv4 state established sport = :5432
+      changed_when: no
+      register: psql_master_connections
+
+    - name: Ensure we have the correct number of connections
+      assert:
+        that:
+          - psql_master_connections.stdout_lines | length == 2
+
+    - name: Query replication slots
+      postgresql_query:
+        query: SELECT * FROM pg_replication_slots
+      register: pg_replication_slots
+      become: yes
+      become_user: postgres
+
+    - name: Ensure the replication slots are created and being used
+      assert:
+        that:
+          - item.slot_name in ['test1', 'slot2']
+          - item.active
+      loop: "{{ pg_replication_slots.query_result }}"
+
+
+- name: Ensure streaming replication is working on replica nodes
+  hosts: database_replica
+  tasks:
+    - name: List PostgreSQL connections
+      command: ss --no-header --tcp --ipv4 state established dport = :5432
+      changed_when: no
+      register: psql_replica_connections
+
+    - name: Ensure we have the correct number of connections
+      assert:
+        that:
+          - psql_replica_connections.stdout_lines | length == 1

--- a/molecule/with_slots/yamllint.yml
+++ b/molecule/with_slots/yamllint.yml
@@ -1,0 +1,16 @@
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  comments-indentation: disable
+  document-start: disable
+  line-length: disable
+  truthy: disable
+
+ignore: |
+  molecule/default/roles

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,5 +14,16 @@
   tags:
     - always
 
+- name: Generate replication slot names
+  set_fact:
+    pgsqlrep_primary_slot_name: "slot{{ ansible_loop.index }}"
+  loop: "{{ groups[pgsqlrep_group_name] }}"
+  loop_control:
+    extended: yes
+  delegate_to: "{{ item }}"
+  delegate_facts: yes
+  run_once: yes
+  when: hostvars[item]['pgsqlrep_primary_slot_name'] is undefined
+
 - include_tasks: "{{ pgsqlrep_role }}.yml"
   when: pgsqlrep_role != 'skip'

--- a/tasks/master.yml
+++ b/tasks/master.yml
@@ -12,9 +12,20 @@
   postgresql_user:
     name: "{{ pgsqlrep_user }}"
     password: "{{ pgsqlrep_password }}"
-    role_attr_flags: replication
+    role_attr_flags: REPLICATION
   become: yes
   become_user: postgres
+
+- name: Create replication slots
+  postgresql_slot:
+    slot_name: "{{ item }}"
+    slot_type: physical
+    state: present
+  loop: "{{ groups[pgsqlrep_group_name] | map('extract', hostvars, 'pgsqlrep_primary_slot_name') | list }}"
+  become: yes
+  become_user: postgres
+  when:
+    - pgsqlrep_use_slots
 
 - name: Add trust in pg_hba.conf
   lineinfile:

--- a/tasks/replica.yml
+++ b/tasks/replica.yml
@@ -16,7 +16,7 @@
     group: postgres
     mode: '0700'
 
-- name: Create base backup
+- name: Create base backup not using replication slots
   command: pg_basebackup -X stream -D {{ pgsqlrep_data_path[pgsql_major_version] }} -h {{ pgsqlrep_master_address }} -U {{ pgsqlrep_user }}
   environment:
     PATH: /opt/rh/rh-postgresql10/root/usr/bin:{{ ansible_env.PATH }}
@@ -27,6 +27,20 @@
     PKG_CONFIG_PATH: /opt/rh/rh-postgresql10/root/usr/lib64/pkgconfig
   become: yes
   become_user: postgres
+  when: not pgsqlrep_use_slots
+
+- name: Create base backup using replication slots
+  command: pg_basebackup -S {{ pgsqlrep_primary_slot_name }} -X stream -D {{ pgsqlrep_data_path[pgsql_major_version] }} -h {{ pgsqlrep_master_address }} -U {{ pgsqlrep_user }}
+  environment:
+    PATH: /opt/rh/rh-postgresql10/root/usr/bin:{{ ansible_env.PATH }}
+    LIBRARY_PATH: /opt/rh/rh-postgresql10/root/usr/lib64
+    JAVACONFDIRS: '/etc/opt/rh/rh-postgresql10/java:/etc/java'
+    LD_LIBRARY_PATH: /opt/rh/rh-postgresql10/root/usr/lib64
+    CPATH: /opt/rh/rh-postgresql10/root/usr/include
+    PKG_CONFIG_PATH: /opt/rh/rh-postgresql10/root/usr/lib64/pkgconfig
+  become: yes
+  become_user: postgres
+  when: pgsqlrep_use_slots
 
 - name: Create recovery.conf
   template:

--- a/templates/recovery.conf.j2
+++ b/templates/recovery.conf.j2
@@ -1,3 +1,6 @@
 standby_mode=on
 trigger_file='/tmp/promotedb'
 primary_conninfo='host={{ pgsqlrep_master_address }} port={{ pg_port }} user={{ pgsqlrep_user }} application_name={{ pgsqlrep_application_name }}'
+{% if pgsqlrep_use_slots %}
+primary_slot_name='{{ pgsqlrep_primary_slot_name }}'
+{% endif %}


### PR DESCRIPTION
The use of replication slots is now an option when setting up
streaming replication. Replication slots make replication more
robust in the event that a replica stops streaming. The trade off
is that failover and recovery are bit more cumbersome.

resolves samdoran/ansible-role-pgsql-replication#18